### PR TITLE
fix: e2e test fail randomly with a network error

### DIFF
--- a/example/integration_test/bucketeer_flutter_sdk_test.dart
+++ b/example/integration_test/bucketeer_flutter_sdk_test.dart
@@ -55,7 +55,7 @@ void main() async {
           .build();
       final user = BKTUserBuilder().id(userId).customAttributes({}).build();
 
-      await BKTClient.initialize(
+      await E2EBKTClient.initializeWithRetryMechanism(
         config: config,
         user: user,
       ).then(
@@ -305,7 +305,7 @@ void main() async {
           .build();
       final user = BKTUserBuilder().id("test_id").customAttributes({}).build();
 
-      var instanceResult = await BKTClient.initialize(
+      var instanceResult = await E2EBKTClient.initializeWithRetryMechanism(
         config: config,
         user: user,
       );
@@ -355,7 +355,7 @@ void main() async {
       assert(config.featureTag == "");
       final user = BKTUserBuilder().id(userId).customAttributes({}).build();
 
-      await BKTClient.initialize(
+      await E2EBKTClient.initializeWithRetryMechanism(
         config: config,
         user: user,
       ).then((instanceResult) {
@@ -441,7 +441,7 @@ void main() async {
       assert(config.featureTag == "");
       final user = BKTUserBuilder().id(userId).customAttributes({}).build();
 
-      await BKTClient.initialize(
+      await E2EBKTClient.initializeWithRetryMechanism(
         config: config,
         user: user,
       ).then((instanceResult) {
@@ -499,5 +499,32 @@ void main() async {
 extension InitializeSuccess on BKTResult<void> {
   bool isInitializeSuccess() {
     return isSuccess || asFailure.exception is BKTTimeoutException;
+  }
+}
+
+class E2EBKTClient {
+  /// This func will retry the BKTClient.initialize 3 times (default) if we got a network error.
+  static Future<BKTResult<void>> initializeWithRetryMechanism({
+    required BKTConfig config,
+    required BKTUser user,
+    int? timeoutMillis,
+    int maxRetryTimes = 3,
+  }) async {
+    var retryCount = 0;
+    BKTResult<void>? result;
+    do {
+      result = await BKTClient.initialize(
+        config: config,
+        user: user,
+        timeoutMillis: timeoutMillis,
+      );
+      bool shouldRetry = result.isFailure && result.asFailure is BKTNetworkException;
+      if (shouldRetry) {
+        retryCount++;
+        continue;
+      }
+      break;
+    } while (retryCount < maxRetryTimes);
+    return result;
   }
 }

--- a/example/integration_test/bucketeer_flutter_sdk_test.dart
+++ b/example/integration_test/bucketeer_flutter_sdk_test.dart
@@ -502,7 +502,7 @@ extension InitializeSuccess on BKTResult<void> {
   }
 }
 
-class E2EBKTClient {
+extension E2EBKTClient on BKTClient {
   /// This func will retry the BKTClient.initialize 3 times (default) if we got a network error.
   static Future<BKTResult<void>> initializeWithRetryMechanism({
     required BKTConfig config,


### PR DESCRIPTION
This pull request added logic to retry initializing the BKTClient when it encounters a network error. This error typically occurs in the CI pipeline of this repository
`Network connection error: Unable to resolve host "[api-dev.bucketeer.jp](http://api-dev.bucketeer.jp/)`