### PR TITLE
fix(android): cache not being updated in the background after initialized

### DIFF
--- a/android/src/main/kotlin/io/bucketeer/sdk/flutter/BucketeerFlutterClientSdkPlugin.kt
+++ b/android/src/main/kotlin/io/bucketeer/sdk/flutter/BucketeerFlutterClientSdkPlugin.kt
@@ -67,14 +67,14 @@ class BucketeerFlutterClientSdkPlugin : MethodCallHandler, FlutterPlugin {
     val apiEndpoint = call.argument("apiEndpoint") as? String
     val featureTag = (call.argument("featureTag") as? String) ?: ""
     val eventsFlushInterval =
-      call.argument("eventsFlushInterval") as? Long
+      call.argument("eventsFlushInterval") as? Int
     val eventsMaxQueueSize =
       call.argument("eventsMaxQueueSize") as? Int
     val pollingInterval =
-      call.argument("pollingInterval") as? Long
+      call.argument("pollingInterval") as? Int
     val backgroundPollingInterval =
-      call.argument("backgroundPollingInterval") as? Long
-    val timeoutMillis = call.argument("timeoutMillis") as? Long
+      call.argument("backgroundPollingInterval") as? Int
+    val timeoutMillis = call.argument("timeoutMillis") as? Int
     val appVersion = call.argument("appVersion") as? String
     val userAttributes = call.argument("userAttributes") as? Map<String, String> ?: mapOf()
     if (apiKey.isNullOrEmpty()) {
@@ -96,7 +96,7 @@ class BucketeerFlutterClientSdkPlugin : MethodCallHandler, FlutterPlugin {
         .apiEndpoint(apiEndpoint)
         .featureTag(featureTag).let {
           if (eventsFlushInterval != null && eventsFlushInterval > 0) {
-            return@let it.eventsFlushInterval(eventsFlushInterval)
+            return@let it.eventsFlushInterval(eventsFlushInterval.toLong())
           }
           return@let it
         }.let {
@@ -106,12 +106,12 @@ class BucketeerFlutterClientSdkPlugin : MethodCallHandler, FlutterPlugin {
           return@let it
         }.let {
           if (pollingInterval != null && pollingInterval > 0) {
-            return@let it.pollingInterval(pollingInterval)
+            return@let it.pollingInterval(pollingInterval.toLong())
           }
           return@let it
         }.let {
           if (backgroundPollingInterval != null && backgroundPollingInterval > 0) {
-            return@let it.pollingInterval(backgroundPollingInterval)
+            return@let it.backgroundPollingInterval(backgroundPollingInterval.toLong())
           }
           return@let it
         }.let {
@@ -128,7 +128,7 @@ class BucketeerFlutterClientSdkPlugin : MethodCallHandler, FlutterPlugin {
         .build()
 
       val future: Future<BKTException?> = if (timeoutMillis != null) {
-        BKTClient.initialize(applicationContext!!, config, user, timeoutMillis)
+        BKTClient.initialize(applicationContext!!, config, user, timeoutMillis.toLong())
       } else {
         BKTClient.initialize(applicationContext!!, config, user)
       }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Bucketeer (2.2.1)
-  - bucketeer_flutter_client_sdk (2.1.0):
+  - bucketeer_flutter_client_sdk (2.1.1):
     - Bucketeer (= 2.2.1)
     - Flutter
   - Flutter (1.0.0)
@@ -37,7 +37,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Bucketeer: 8b7f89fe85599dd5c18384fd9fd6aaa7ee5388bc
-  bucketeer_flutter_client_sdk: ec0738228b7abdab817a45ad6c6b719afdde7e72
+  bucketeer_flutter_client_sdk: 99397306b613410150a27094e442c1a56c5cb1f4
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bucketeer_flutter_client_sdk
 description: Bucketeer
-version: 2.1.1
+version: 2.1.2
 homepage: https://bucketeer.io/
 repository: https://github.com/bucketeer-io/flutter-client-sdk
 documentation: https://docs.bucketeer.io/sdk/client-side/flutter


### PR DESCRIPTION
### Issues
The pollingInterval was not set correctly in the Android code, causing the SDK to fail to update the feature flag on time.
This PR updates the code to handle the conversion correctly and fixes the issue where casting from Int to Long in Kotlin returns null when using optional casting.
Unlike Java, Kotlin does not support implicit conversion between Int and Long.

### Changes
* Changed the data types of `eventsFlushInterval`, `pollingInterval`, `backgroundPollingInterval`, and `timeoutMillis` from `Long` to `Int` in the method call arguments.
* Updated the `eventsFlushInterval` argument to be converted to `Long` before being used in the `eventsFlushInterval` method.
* Updated the `pollingInterval` argument to be converted to `Long` before being used in the `pollingInterval` method.
* Updated the `backgroundPollingInterval` argument to be converted to `Long` before being used in the `backgroundPollingInterval` method.
* Updated the `timeoutMillis` argument to be converted to `Long` before being used in the `BKTClient.initialize` method.