### PR TITLE
ci: update flutter & android environments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Cache Flutter dependencies
         uses: actions/cache@v4
         with:
-          path: /Users/runner/hostedtoolcache/flutter # For mac OS
+          path: ${{ runner.tool_cache }}/flutter
           key: ${{ runner.os }}-flutter-install-cache-${{ env.FLUTTER_VERSION }}
 
       - name: Setup Flutter SDK
@@ -77,7 +77,7 @@ jobs:
       - name: Cache Flutter dependencies
         uses: actions/cache@v4
         with:
-          path: /Users/runner/hostedtoolcache/flutter # For mac OS
+          path: ${{ runner.tool_cache }}/flutter
           key: ${{ runner.os }}-flutter-install-cache-${{ env.FLUTTER_VERSION }}
 
       - name: Setup Flutter SDK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/ci-cd-update
     paths-ignore:
       - "*.md"
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat/ci-cd-update
     paths-ignore:
       - "*.md"
   workflow_dispatch:
@@ -29,7 +30,7 @@ jobs:
           key: ${{ runner.os }}-flutter-install-cache-${{ env.FLUTTER_VERSION }}
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@62f096cacda5168a3bd7b95793373be14fa4fbaf # v2.13.0
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff # v2.18.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
@@ -41,7 +42,7 @@ jobs:
         run: make unit-test
 
   build-example-app-android:
-    runs-on: macos-13-xlarge
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -53,7 +54,7 @@ jobs:
           key: ${{ runner.os }}-flutter-install-cache-${{ env.FLUTTER_VERSION }}
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@62f096cacda5168a3bd7b95793373be14fa4fbaf # v2.13.0
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff # v2.18.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
@@ -68,7 +69,7 @@ jobs:
           make build-android
 
   build-example-app-ios:
-    runs-on: macos-13-xlarge
+    runs-on: macos-15-xlarge
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -80,7 +81,7 @@ jobs:
           key: ${{ runner.os }}-flutter-install-cache-${{ env.FLUTTER_VERSION }}
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@62f096cacda5168a3bd7b95793373be14fa4fbaf # v2.13.0
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff # v2.18.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Cache Flutter dependencies
         uses: actions/cache@v4
         with:
-          path: /Users/runner/hostedtoolcache/flutter # For mac OS
+          path: ${{ runner.tool_cache }}/flutter
           key: ${{ runner.os }}-flutter-install-cache-${{ env.FLUTTER_VERSION }}
 
       - name: Setup Flutter SDK
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         api-level:
-          - 32
+          - 33
         target:
           - google_apis
         arch:
@@ -79,7 +79,7 @@ jobs:
       - name: Cache Flutter dependencies
         uses: actions/cache@v4
         with:
-          path: /Users/runner/hostedtoolcache/flutter # For mac OS
+          path: ${{ runner.tool_cache }}/flutter
           key: ${{ runner.os }}-flutter-install-cache-${{ env.FLUTTER_VERSION }}
 
       - name: Setup Flutter SDK

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat/ci-cd-update
     paths-ignore:
       - "*.md"
   workflow_dispatch:
@@ -14,7 +15,7 @@ env:
 
 jobs:
   ios-integration-test:
-    runs-on: macos-13-xlarge
+    runs-on: macos-15-xlarge
     timeout-minutes: 45
     strategy:
       matrix:
@@ -44,7 +45,7 @@ jobs:
           key: ${{ runner.os }}-flutter-install-cache-${{ env.FLUTTER_VERSION }}
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@62f096cacda5168a3bd7b95793373be14fa4fbaf # v2.13.0
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff # v2.18.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
@@ -59,8 +60,7 @@ jobs:
         run: make e2e
 
   android-integration-test:
-    # macos-13-xlarge is an M1 mac (which has no Android SDK)
-    runs-on: macos-13-large
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       matrix:
@@ -83,7 +83,7 @@ jobs:
           key: ${{ runner.os }}-flutter-install-cache-${{ env.FLUTTER_VERSION }}
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@62f096cacda5168a3bd7b95793373be14fa4fbaf # v2.13.0
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff # v2.18.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
@@ -100,9 +100,15 @@ jobs:
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@6b0df4b0efb23bb0ec63d881db79aefbc976e4b2 # v2.30.1
+        uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # v2.33.0
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
@@ -118,7 +124,7 @@ jobs:
           BKT_API_KEY: ${{ secrets.BKT_API_KEY }}
           BKT_API_ENDPOINT: ${{ secrets.BKT_API_ENDPOINT }}
           GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx1536m -XX:MaxMetaspaceSize=2g"
-        uses: reactivecircus/android-emulator-runner@6b0df4b0efb23bb0ec63d881db79aefbc976e4b2 # v2.30.1
+        uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # v2.33.0
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         device:
           # the name of the simulator could be different depending on the macos version you are using
-          - "iPhone 15 Simulator (17.2)"
+          - "iPhone 16 Simulator (18.0)"
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/ci-cd-update
     paths-ignore:
       - "*.md"
   workflow_dispatch:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           key: ${{ runner.os }}-flutter-install-cache-${{ env.FLUTTER_VERSION }}
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@62f096cacda5168a3bd7b95793373be14fa4fbaf # v2.13.0
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff # v2.13.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: "stable"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,7 +26,7 @@ jobs:
           key: ${{ runner.os }}-flutter-install-cache-${{ env.FLUTTER_VERSION }}
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@62f096cacda5168a3bd7b95793373be14fa4fbaf # v2.13.0
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff # v2.13.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable


### PR DESCRIPTION
This pull request includes several updates to the CI/CD workflows, primarily focusing on updating the Flutter SDK version and changing the runner environments. 

**It reduced the Android E2e test from 20 mins to 7 mins**

### CI/CD Workflow Updates:

* **Runner Environment Updates:**
  * Changed the runner environment for `build-example-app-android` from `macos-13-xlarge` to `ubuntu-latest` in `build.yml`.
  * Updated the runner environment for `build-example-app-ios` from `macos-13-xlarge` to `macos-15-xlarge` in `build.yml`.
  * Changed the runner environment for `ios-integration-test` from `macos-13-xlarge` to `macos-15-xlarge` in `e2e.yml`.
  * Updated the runner environment for `android-integration-test` from `macos-13-large` to `ubuntu-latest` in `e2e.yml`.

* **Flutter SDK Version Update:**
  * Updated the Flutter SDK version from `v2.13.0` to `v2.18.0` across all workflows (`build.yml`, `e2e.yml`, `publish.yml`, and `pull-request.yml`). [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L32-R33) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L44-R57) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L71-R84) [[4]](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eL43-R48) [[5]](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eL82-R86) [[6]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L27-R27) [[7]](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L29-R29)

* **Additional Changes in `e2e.yml`:**
  * Updated iPhone simulator version from "iPhone 15 Simulator (17.2)" to "iPhone 16 Simulator (18.0)".
  * Enabled KVM for Android integration tests.
  * Updated `reactivecircus/android-emulator-runner` action from `v2.30.1` to `v2.33.0`. [[1]](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eR103-R111) [[2]](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eL121-R127)