### PR TITLE
ci: fix enable to find a destination matching the provided destination specifier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
           make build-android
 
   build-example-app-ios:
-    runs-on: macos-15-xlarge
+    runs-on: macos-14-xlarge
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   ios-integration-test:
-    runs-on: macos-15-xlarge
+    runs-on: macos-14-xlarge
     timeout-minutes: 30
     env:
       XCODE_VERSION: '16.2'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configurations to use the `macos-14-xlarge` runner instead of `macos-15-xlarge` for both the iOS build and integration test jobs. This change may be necessary due to runner availability or compatibility requirements.
Related to this changes from Github https://github.com/actions/runner-images/issues/12541

Workflow runner updates:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L71-R71): Changed the `build-example-app-ios` job to run on `macos-14-xlarge` instead of `macos-15-xlarge`.
* [`.github/workflows/e2e.yml`](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eL17-R17): Updated the `ios-integration-test` job to use `macos-14-xlarge` instead of `macos-15-xlarge`.