### PR TITLE
ci: augment release-please CHANGELOG with native SDK release notes

### DIFF
--- a/.github/native-sdk-changelog.config.json
+++ b/.github/native-sdk-changelog.config.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "./native-sdk-changelog.schema.json",
+  "natives": [
+    {
+      "name": "iOS SDK",
+      "shortName": "ios-client-sdk",
+      "repo": "bucketeer-io/ios-client-sdk",
+      "versionFile": "ios/bucketeer_flutter_client_sdk.podspec",
+      "versionRegex": "s\\.dependency\\s+'Bucketeer',\\s+'([^']+)'"
+    },
+    {
+      "name": "Android SDK",
+      "shortName": "android-client-sdk",
+      "repo": "bucketeer-io/android-client-sdk",
+      "versionFile": "android/build.gradle",
+      "versionRegex": "io\\.bucketeer:android-client-sdk:([^'\"]+)"
+    }
+  ],
+  "skipPatterns": [
+    "^\\*\\*deps:\\*\\*\\s+update\\s+all\\s+non-major\\s+dependencies"
+  ],
+  "sectionOrder": [
+    "Features",
+    "Bug Fixes",
+    "Performance Improvements",
+    "Reverts",
+    "Refactoring",
+    "Miscellaneous",
+    "Build System"
+  ]
+}

--- a/.github/native-sdk-changelog.config.json
+++ b/.github/native-sdk-changelog.config.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "./native-sdk-changelog.schema.json",
   "natives": [
     {
       "name": "iOS SDK",

--- a/.github/scripts/augment-changelog.mjs
+++ b/.github/scripts/augment-changelog.mjs
@@ -18,7 +18,6 @@
 
 import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
-import path from "node:path";
 import process from "node:process";
 
 const CONFIG_PATH = ".github/native-sdk-changelog.config.json";

--- a/.github/scripts/augment-changelog.mjs
+++ b/.github/scripts/augment-changelog.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+// Augments CHANGELOG.md with native SDK release notes for the topmost release.
+//
+// Reads .github/native-sdk-changelog.config.json to learn which dependency files
+// to inspect, fetches GitHub release bodies for every native version between
+// the base ref (typically main) and HEAD, aggregates them by section, and
+// splices a "Native SDK Changes" block under the latest release heading.
+//
+// The block is enclosed in sentinel HTML comments so it can be removed and
+// regenerated cleanly on every run (idempotent across release-please force
+// pushes).
+//
+// Usage:
+//   node .github/scripts/augment-changelog.mjs --base-ref origin/main
+//
+// Env:
+//   GH_TOKEN  GitHub token used by the `gh` CLI to fetch release bodies.
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const CONFIG_PATH = ".github/native-sdk-changelog.config.json";
+const CHANGELOG_PATH = "CHANGELOG.md";
+const SENTINEL_START = "<!-- native-sdk-changes:start -->";
+const SENTINEL_END = "<!-- native-sdk-changes:end -->";
+
+function gh(args) {
+  return execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] });
+}
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] });
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseSemver(v) {
+  const cleaned = String(v).replace(/^v/, "").trim();
+  const match = cleaned.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareSemver(a, b) {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) return String(a).localeCompare(String(b));
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+async function readVersion(filePath, regex, ref) {
+  let content;
+  if (ref) {
+    try {
+      content = git(["show", `${ref}:${filePath}`]);
+    } catch (err) {
+      throw new Error(`Could not read ${filePath} at ${ref}: ${err.message}`);
+    }
+  } else {
+    content = await fs.readFile(filePath, "utf8");
+  }
+  const m = content.match(new RegExp(regex));
+  if (!m) {
+    throw new Error(`Could not match ${regex} in ${filePath}${ref ? ` at ${ref}` : ""}`);
+  }
+  return m[1];
+}
+
+function fetchReleasesBetween(repo, fromVersion, toVersion) {
+  // GitHub Releases via gh CLI. Walk the most recent 100 releases and filter
+  // to (fromVersion, toVersion]. 100 is enough for any wrapper SDK that bumps
+  // a few times per year; bump if needed.
+  const raw = gh([
+    "release",
+    "list",
+    "--repo",
+    repo,
+    "--limit",
+    "100",
+    "--json",
+    "tagName,name,publishedAt",
+  ]);
+  const releases = JSON.parse(raw);
+  const inRange = releases
+    .map((r) => ({ ...r, version: r.tagName.replace(/^v/, "") }))
+    .filter((r) => parseSemver(r.version))
+    .filter((r) => compareSemver(r.version, fromVersion) > 0 && compareSemver(r.version, toVersion) <= 0)
+    .sort((a, b) => compareSemver(b.version, a.version));
+
+  // Fetch bodies one-by-one so we don't pull bodies for unrelated releases.
+  for (const r of inRange) {
+    const body = gh([
+      "release",
+      "view",
+      r.tagName,
+      "--repo",
+      repo,
+      "--json",
+      "body",
+      "--jq",
+      ".body",
+    ]);
+    r.body = body || "";
+  }
+  return inRange;
+}
+
+function parseReleaseBody(body) {
+  // release-please bodies look like:
+  //   ### Features
+  //
+  //   * item one ([#1](url))
+  //   * item two
+  //
+  //   ### Bug Fixes
+  //   ...
+  //
+  // Be lenient: accept ## or ### headings (release-please uses ###), and
+  // accept either `*` or `-` bullets.
+  const sections = {};
+  const lines = body.split(/\r?\n/);
+  let current = null;
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\s+$/, "");
+    const heading = line.match(/^#{2,4}\s+(.+?)\s*$/);
+    if (heading) {
+      const title = heading[1].trim();
+      // Skip anchor headings like the version range header that release-please
+      // sometimes emits at the top of a body (it does not for our setup, but
+      // safe to ignore non-section ones if encountered).
+      current = title;
+      sections[current] ??= [];
+      continue;
+    }
+    if (!current) continue;
+    const bullet = line.match(/^\s*[-*]\s+(.+)$/);
+    if (bullet) {
+      sections[current].push(bullet[1].trim());
+    }
+  }
+  // Drop empty sections.
+  for (const k of Object.keys(sections)) {
+    if (sections[k].length === 0) delete sections[k];
+  }
+  return sections;
+}
+
+function aggregateSections(releases) {
+  const all = {};
+  for (const r of releases) {
+    const sections = parseReleaseBody(r.body || "");
+    for (const [name, items] of Object.entries(sections)) {
+      all[name] ??= [];
+      for (const item of items) {
+        if (!all[name].includes(item)) all[name].push(item);
+      }
+    }
+  }
+  return all;
+}
+
+function rewriteItem(item, native) {
+  // 1. Strip the trailing commit-hash link release-please appends, e.g.
+  //    " ([abc1234](https://github.com/.../commit/abc1234...))".
+  let out = item.replace(
+    /\s*\(\[[0-9a-f]{6,40}\]\(https:\/\/github\.com\/[^)]+\/commit\/[0-9a-f]+\)\)\s*$/,
+    "",
+  );
+
+  // 2. Disambiguate bare issue refs by prefixing with the native repo's short
+  //    name. Only rewrite when the URL points to the native repo so we don't
+  //    accidentally rewrite cross-repo links.
+  const repoEsc = escapeRegex(native.repo);
+  const issueRefRegex = new RegExp(
+    `\\[#(\\d+)\\]\\((https://github\\.com/${repoEsc}/(?:issues|pull)/\\d+)\\)`,
+    "g",
+  );
+  out = out.replace(issueRefRegex, `[${native.shortName}#$1]($2)`);
+
+  return out.trim();
+}
+
+function renderNativeSection(native, fromVersion, toVersion, sections, config) {
+  const compareUrl = `https://github.com/${native.repo}/compare/v${fromVersion}...v${toVersion}`;
+  const lines = [];
+  lines.push(`#### ${native.name} ([v${fromVersion}...v${toVersion}](${compareUrl}))`);
+  lines.push("");
+
+  const skipPatterns = (config.skipPatterns || []).map((p) => new RegExp(p));
+  const ordered = config.sectionOrder || [];
+  const seen = new Set();
+  const emitSection = (name, items) => {
+    const filtered = items
+      .map((it) => rewriteItem(it, native))
+      .filter((it) => it.length > 0)
+      .filter((it) => !skipPatterns.some((re) => re.test(it)));
+    if (filtered.length === 0) return;
+    seen.add(name);
+    lines.push(`##### ${name}`);
+    lines.push("");
+    for (const item of filtered) {
+      lines.push(`* ${item}`);
+    }
+    lines.push("");
+  };
+
+  for (const name of ordered) {
+    if (sections[name]) emitSection(name, sections[name]);
+  }
+  // Emit any unexpected sections after the configured order, alphabetised.
+  for (const name of Object.keys(sections).sort()) {
+    if (seen.has(name)) continue;
+    emitSection(name, sections[name]);
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function spliceIntoChangelog(changelog, augmentation) {
+  // Drop any existing sentinel block first so we always start from the
+  // release-please-generated baseline. This is what makes the workflow safe
+  // to re-run after release-please force-pushes.
+  const sentinelRegex = new RegExp(
+    `\\n*${escapeRegex(SENTINEL_START)}[\\s\\S]*?${escapeRegex(SENTINEL_END)}\\n*`,
+    "g",
+  );
+  let cleaned = changelog.replace(sentinelRegex, "\n");
+
+  // Find the topmost `## ` heading (the new release).
+  const firstHeadingMatch = cleaned.match(/^## .+$/m);
+  if (!firstHeadingMatch) {
+    throw new Error("Could not find a release heading (`## ...`) in CHANGELOG.md");
+  }
+  const firstHeadingIdx = cleaned.indexOf(firstHeadingMatch[0]);
+  const afterFirstHeading = firstHeadingIdx + firstHeadingMatch[0].length;
+
+  // Find the next `## ` heading (start of previous release).
+  const nextHeadingRegex = /\n## /g;
+  nextHeadingRegex.lastIndex = afterFirstHeading;
+  const nextMatch = nextHeadingRegex.exec(cleaned);
+  const insertionPoint = nextMatch ? nextMatch.index : cleaned.length;
+
+  const before = cleaned.slice(0, insertionPoint).replace(/\s+$/, "");
+  const after = cleaned.slice(insertionPoint);
+
+  const block = [
+    "",
+    "",
+    SENTINEL_START,
+    "",
+    augmentation,
+    SENTINEL_END,
+    "",
+  ].join("\n");
+
+  return `${before}${block}${after.startsWith("\n") ? after : `\n${after}`}`;
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--base-ref") args.baseRef = argv[++i];
+    else if (a === "--config") args.configPath = argv[++i];
+    else if (a === "--changelog") args.changelogPath = argv[++i];
+    else if (a === "--dry-run") args.dryRun = true;
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const baseRef = args.baseRef || "origin/main";
+  const configPath = args.configPath || CONFIG_PATH;
+  const changelogPath = args.changelogPath || CHANGELOG_PATH;
+
+  const config = JSON.parse(await fs.readFile(configPath, "utf8"));
+  if (!Array.isArray(config.natives) || config.natives.length === 0) {
+    console.log("No native SDKs configured, nothing to do.");
+    return;
+  }
+
+  const augmentations = [];
+  for (const native of config.natives) {
+    const newVersion = await readVersion(native.versionFile, native.versionRegex);
+    let oldVersion;
+    try {
+      oldVersion = await readVersion(native.versionFile, native.versionRegex, baseRef);
+    } catch (err) {
+      console.warn(`[${native.name}] could not read base version, skipping: ${err.message}`);
+      continue;
+    }
+
+    if (compareSemver(newVersion, oldVersion) <= 0) {
+      console.log(`[${native.name}] no upgrade (${oldVersion} -> ${newVersion}), skipping`);
+      continue;
+    }
+
+    console.log(`[${native.name}] ${oldVersion} -> ${newVersion}, fetching release notes`);
+    let releases;
+    try {
+      releases = fetchReleasesBetween(native.repo, oldVersion, newVersion);
+    } catch (err) {
+      console.warn(`[${native.name}] failed to fetch releases: ${err.message}`);
+      continue;
+    }
+    if (releases.length === 0) {
+      console.warn(`[${native.name}] no GitHub releases found in (${oldVersion}, ${newVersion}], skipping`);
+      continue;
+    }
+    console.log(`[${native.name}] found ${releases.length} release(s): ${releases.map((r) => r.tagName).join(", ")}`);
+
+    const sections = aggregateSections(releases);
+    if (Object.keys(sections).length === 0) {
+      console.warn(`[${native.name}] release bodies contained no parseable sections, skipping`);
+      continue;
+    }
+    augmentations.push(renderNativeSection(native, oldVersion, newVersion, sections, config));
+  }
+
+  if (augmentations.length === 0) {
+    console.log("No native SDK upgrades found, leaving CHANGELOG.md untouched.");
+    return;
+  }
+
+  const intro = [
+    "### Native SDK Changes",
+    "",
+    "This release also brings the following changes from the underlying native SDKs.",
+  ].join("\n");
+  const fullBlock = `${intro}\n\n${augmentations.join("\n\n")}\n`;
+
+  const original = await fs.readFile(changelogPath, "utf8");
+  const updated = spliceIntoChangelog(original, fullBlock);
+
+  if (updated === original) {
+    console.log("CHANGELOG.md already up to date.");
+    return;
+  }
+
+  if (args.dryRun) {
+    console.log("--- diff (dry run) ---");
+    console.log(updated);
+    return;
+  }
+
+  await fs.writeFile(changelogPath, updated);
+  console.log(`Updated ${changelogPath}.`);
+}
+
+main().catch((err) => {
+  console.error(err.stack || err.message || String(err));
+  process.exit(1);
+});

--- a/.github/workflows/augment-release-please-changelog.yml
+++ b/.github/workflows/augment-release-please-changelog.yml
@@ -21,10 +21,15 @@ concurrency:
 
 jobs:
   augment:
-    # Only run on release-please's branches. release-please names them
-    # `release-please--branches--<base>` (or similar) so a prefix match is the
-    # most resilient check across plugin versions.
-    if: startsWith(github.head_ref, 'release-please--')
+    # Only run on release-please branches that originate from THIS repo.
+    # release-please names its branches `release-please--branches--<base>`
+    # (or similar) so a prefix match is the most resilient check across
+    # plugin versions. The repo check prevents a forked PR that happens to
+    # reuse the same branch name from triggering this workflow (it would
+    # only get a read-only token and fail noisily at push time anyway).
+    if: >-
+      startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/augment-release-please-changelog.yml
+++ b/.github/workflows/augment-release-please-changelog.yml
@@ -1,0 +1,75 @@
+# Augments release-please's auto-generated CHANGELOG.md with release notes
+# from the native iOS and Android SDKs whenever the release-please PR bumps
+# them.
+#
+# The script is idempotent (uses sentinel HTML comments) so this workflow can
+# safely re-run after release-please force-pushes its branch.
+name: Augment release-please CHANGELOG
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: augment-changelog-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  augment:
+    # Only run on release-please's branches. release-please names them
+    # `release-please--branches--<base>` (or similar) so a prefix match is the
+    # most resilient check across plugin versions.
+    if: startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Fetch tags
+        run: git fetch --tags --force origin
+
+      - name: Determine previous release tag
+        id: previous
+        run: |
+          # The wrapper SDK PR that bumps the native dep versions lands on
+          # `main` before release-please opens the release PR, so comparing
+          # against `main` would show no diff. Compare against the previous
+          # release tag instead (the most recent tag reachable from main).
+          PREV_TAG="$(git describe --tags --abbrev=0 "origin/${{ github.base_ref }}")"
+          echo "tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Previous release tag: ${PREV_TAG}"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Augment CHANGELOG.md with native SDK changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/augment-changelog.mjs --base-ref "${{ steps.previous.outputs.tag }}"
+
+      - name: Commit and push if changed
+        run: |
+          if [[ -z "$(git status --porcelain CHANGELOG.md)" ]]; then
+            echo "No changes to CHANGELOG.md."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "docs(changelog): augment with native SDK release notes"
+          # Pushing with GITHUB_TOKEN does not retrigger workflows, so this
+          # cannot loop with itself. release-please pushes (using its PAT)
+          # will retrigger this workflow, and the script's sentinels make
+          # the augmentation re-apply cleanly.
+          git push origin "HEAD:${{ github.head_ref }}"


### PR DESCRIPTION
## Summary

Adds a workflow that runs on every release-please PR and augments the
auto-generated `CHANGELOG.md` with release notes from the native iOS and
Android SDKs whenever a release bumps `Bucketeer` (iOS) or
`io.bucketeer:android-client-sdk` (Android).

This removes the manual step of curating native SDK changes into the Flutter
changelog (as was done by hand for `v2.2.0` in c628df2).

## Why

The Flutter SDK is a thin wrapper around the iOS and Android native SDKs.
When a Flutter release bumps the underlying native dep versions, end users
have no way to discover what changed in the underlying SDKs unless they
manually cross-reference the iOS and Android changelogs. release-please only
sees commits from this repo, so the native changes never appear in
`CHANGELOG.md`.

## How it works

1. `pull_request` events on branches matching `release-please--*` trigger
   `.github/workflows/augment-release-please-changelog.yml`.
2. The workflow derives the previous release tag from
   `git describe --tags --abbrev=0 origin/main` (the wrapper-SDK PR that
   bumps the native deps lands on `main` *before* release-please opens its
   PR, so comparing against `main` would show no diff — comparing against
   the previous tag is what we want).
3. `.github/scripts/augment-changelog.mjs` reads the configured native SDKs
   from `.github/native-sdk-changelog.config.json`, computes the version
   diff per SDK, walks GitHub Releases via `gh release view`, aggregates
   entries by section (Features, Bug Fixes, Miscellaneous, Build System,
   etc.), and splices a `### Native SDK Changes` block under the new
   release heading.
4. The block is enclosed in sentinel HTML comments so re-runs are
   idempotent — release-please's force-pushes regenerate the section
   cleanly without duplicates.
5. The workflow commits with `GITHUB_TOKEN`, which by design does not
   re-trigger workflows, preventing self-loops.

## Files added

- `.github/native-sdk-changelog.config.json` — declares the native SDKs to
  watch (file path + version regex + repo slug). Easily extensible to other
  wrappers (e.g. React Native) later.
- `.github/scripts/augment-changelog.mjs` — Node 20 script (no npm deps).
- `.github/workflows/augment-release-please-changelog.yml` — the trigger.

## Permissions

- `GITHUB_TOKEN` with `contents: write` (declared per-workflow, no repo
  setting changes needed assuming the org allows per-workflow elevation,
  which is the GitHub default).
- The existing `WORKFLOW_TOKEN` is unchanged. It's required for the trigger
  chain to work: release-please pushes via `WORKFLOW_TOKEN` (a PAT), which
  is what allows downstream workflows like this one to fire on its PR.

## Test plan

Verified locally end-to-end against the current `release-please--branches--main`
branch by stubbing the `gh` CLI to read from local clones of the native
repos:

- [x] **Both natives bumped** (v2.1.2 → v2.2.0): produces output identical
      to the manual c628df2 edit (faithfully preserves upstream typos and
      punctuation).
- [x] **Only iOS bumped**: renders only the iOS subsection, no Android
      heading.
- [x] **Only Android bumped**: renders only the Android subsection, no iOS
      heading. Aggregates correctly across multi-version jumps (here 6
      intermediate releases v2.2.2 → v2.3.1).
- [x] **No native bumps**: file SHA-256 unchanged before and after; the
      workflow's `git status --porcelain` guard short-circuits commit/push.
- [x] **Idempotency**: re-running on an already-augmented file leaves it
      byte-for-byte identical (sentinel comments allow clean
      regeneration).

Live verification will happen on the next release-please PR after merge.